### PR TITLE
#4 - errorText is not a function

### DIFF
--- a/src/helpers/logging.js
+++ b/src/helpers/logging.js
@@ -7,13 +7,13 @@ export default {
   success
 }
 
-const errorText = clc.red.bold
+const errorText = clc.red
 const dateText = clc.blue
 const successText = clc.green
 
 export function error (...args) {
-  const errorArgs = args.map((a) => errorText(a))
-  console.log(errorText(new Date().toISOString()), ':', ...errorArgs)
+  const errorArgs = args.map((a) => errorText(JSON.stringify(a, null, 2)))
+  console.log(errorText(new Date().toISOString()), errorText(':'), ...errorArgs)
 }
 
 export function log (...args) {

--- a/src/publish/index.js
+++ b/src/publish/index.js
@@ -65,7 +65,7 @@ function onMigrationSuccess (db) {
 }
 
 function onMigrationFailure (db, error) {
-  logger.error(error)
+  logger.error(error.message)
   return db.MigrationsLog.create({
     status: MigrationStatus.Failed,
     message: error.message,


### PR DESCRIPTION
The ".bold" formatting is not supported on all consoles.
Also made it handle the objects and only log the message.