### PR TITLE
#14 - [Bug] cli requires package password

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ Options:
   -d, --database           (required) Name of the database
   -u, --user               (required) Admin user for connecting to the SQL Server
   -p, --password           (required) Admin user password
-  -l, --packageLogin       (required) IMS package login user, will be created if it doesn't exist
-  -x, --packagePassword    (required) IMS package login password, only used when creating the package login
+  -l, --packageLogin       IMS package login user, will be created if it doesn't exist
+  -x, --packagePassword    IMS package login password, only used when creating the package login (requires that packageLogin also be set)
   -v, --verbose            Prints SQL commands being executed to the console
   -r, --replacements       Custom replacements to be merged with the default replacements. Should be in the format `key=value`
                            May be specified multiple times to pass an array of custom replacements

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ This will create the following directories and files.
 Script files processed prior to being applied to the database. In your scripts you can include a token name inside double curly braces (ex: ```{{DatabaseName}}```). Any instances of this pattern in your script are replaced with the value at runtime. By default, a few replacement tokens are available and custom replacements can be provided when running publish.
 
 ### Default Replacement Tokens
-| Token Name           | Description                                                     |
-| -------------------- | --------------------------------------------------------------- |
-| DatabaseName         | Database name passed in -d or --database                        |
-| PackageLoginUsername | Login name for the package user passed in -l or --packageLogin  |
-| PackageLoginPassword | Password for the package user passed in -x or --packagePassword |
-| PublisherUsername    | Login name passed in -u or --user                               |
-| PublisherPassword    | Password passed in -p or --password                             |
+| Token Name           | Description                                                                                                             |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| DatabaseName         | Database name passed in -d or --database                                                                                |
+| PackageLoginUsername | Login name for the package user passed in -l or --packageLogin (May be an empty string if not provided during publish)  |
+| PackageLoginPassword | Password for the package user passed in -x or --packagePassword (May be an empty string if not provided during publish) |
+| PublisherUsername    | Login name passed in -u or --user                                                                                       |
+| PublisherPassword    | Password passed in -p or --password                                                                                     |
 
 For passing custom tokens see [Publish CLI](#publish-cli) and [Publishing from node](#publishing-from-node).
 

--- a/assets/scripts/createDatabase.sql
+++ b/assets/scripts/createDatabase.sql
@@ -1,6 +1,13 @@
 IF DB_ID(N'{{DatabaseName}}') IS NULL
 BEGIN
 
+  IF N'{{PackageLoginUsername}}' = N'' OR N'{{PackageLoginPassword}}' = N''
+  BEGIN
+
+    ;THROW 51000, 'Package login username and password must be provided when creating a new database.', 1;  
+
+  END
+
   CREATE DATABASE [{{DatabaseName}}];
   ALTER DATABASE [{{DatabaseName}}] SET RECOVERY SIMPLE;
 

--- a/assets/scripts/createPackageDatabaseUser.sql
+++ b/assets/scripts/createPackageDatabaseUser.sql
@@ -1,12 +1,17 @@
-IF NOT EXISTS (
-	SELECT 1 FROM sys.database_principals WHERE name = N'{{PackageLoginUsername}}'
-)
+IF N'{{PackageLoginUsername}}' <> N''
 BEGIN
 
-	PRINT 'Creating database user {{PackageLoginUsername}}...';
+	IF NOT EXISTS (
+		SELECT 1 FROM sys.database_principals WHERE name = N'{{PackageLoginUsername}}'
+	)
+	BEGIN
 
-	CREATE USER [{{PackageLoginUsername}}] FOR LOGIN [{{PackageLoginUsername}}];
+		PRINT 'Creating database user {{PackageLoginUsername}}...';
 
-	ALTER ROLE [db_owner] ADD MEMBER [{{PackageLoginUsername}}];
+		EXEC('CREATE USER [{{PackageLoginUsername}}] FOR LOGIN [{{PackageLoginUsername}}];');
+
+		EXEC('ALTER ROLE [db_owner] ADD MEMBER [{{PackageLoginUsername}}];');
+
+	END
 
 END

--- a/assets/scripts/createPackageLogin.sql
+++ b/assets/scripts/createPackageLogin.sql
@@ -1,18 +1,21 @@
-IF NOT EXISTS (
-	SELECT 1 FROM sys.server_principals WHERE name = N'{{PackageLoginUsername}}'
-)
+IF N'{{PackageLoginUsername}}' <> N''
 BEGIN
+	IF NOT EXISTS (
+		SELECT 1 FROM sys.server_principals WHERE name = N'{{PackageLoginUsername}}'
+	)
+	BEGIN
 
-	PRINT 'Creating login {{PackageLoginUsername}}...';
+		PRINT 'Creating login {{PackageLoginUsername}}...';
 
-	CREATE LOGIN [{{PackageLoginUsername}}] WITH PASSWORD = N'{{PackageLoginPassword}}', DEFAULT_DATABASE = [{{DatabaseName}}], DEFAULT_LANGUAGE = [us_english], CHECK_POLICY = OFF;
+		EXEC('CREATE LOGIN [{{PackageLoginUsername}}] WITH PASSWORD = N''{{PackageLoginPassword}}'', DEFAULT_DATABASE = [{{DatabaseName}}], DEFAULT_LANGUAGE = [us_english], CHECK_POLICY = OFF;');
 
-END
-ELSE IF N'{{PackageLoginPassword}}' <> N''
-BEGIN
+	END
+	ELSE IF N'{{PackageLoginPassword}}' <> N''
+	BEGIN
 
-	PRINT 'Updating password for {{PackageLoginUsername}}...'
+		PRINT 'Updating password for {{PackageLoginUsername}}...'
 
-	ALTER LOGIN [{{PackageLoginUsername}}] WITH PASSWORD = N'{{PackageLoginPassword}}';
+		EXEC('ALTER LOGIN [{{PackageLoginUsername}}] WITH PASSWORD = N''{{PackageLoginPassword}}'';');
 
+	END
 END

--- a/src/cmds/publish.js
+++ b/src/cmds/publish.js
@@ -31,12 +31,12 @@ export const builder = {
   },
   packageLogin: {
     alias: [ 'l' ],
-    default: '',
-    implies: 'packagePassword'
+    default: ''
   },
   packagePassword: {
+    alias: [ 'x' ],
     default: '',
-    alias: [ 'x' ]
+    implies: 'packageLogin'
   },
   verbose: {
     alias: [ 'v' ],

--- a/src/cmds/publish.js
+++ b/src/cmds/publish.js
@@ -31,11 +31,12 @@ export const builder = {
   },
   packageLogin: {
     alias: [ 'l' ],
-    demandOption: true
+    default: '',
+    implies: 'packagePassword'
   },
   packagePassword: {
-    alias: [ 'x' ],
-    demandOption: true
+    default: '',
+    alias: [ 'x' ]
   },
   verbose: {
     alias: [ 'v' ],

--- a/src/publish/index.js
+++ b/src/publish/index.js
@@ -34,13 +34,16 @@ export function publish (options) {
       })
       .catch((error) => onMigrationFailure(db, error))
     })
+    .catch((error) => {
+      logger.error(error)
+    })
 }
 
 function buildReplacements (options) {
   const replacements = {
     DatabaseName: options.database.databaseName,
-    PackageLoginUsername: options.packageLogin.username,
-    PackageLoginPassword: options.packageLogin.password,
+    PackageLoginUsername: options.packageLogin.username || '',
+    PackageLoginPassword: options.packageLogin.password || '',
     PublisherUsername: options.database.username,
     PublisherPassword: options.database.password
   }


### PR DESCRIPTION
Modified the cli to allow both package login and password to be omitted under the following conditions.

1. If a new database is being created, both package login and package password must be provided. This generates a publish Sequelize exception.
2. If package password is set then package login must also be provided.

Also, made notes in read me regarding the possibility of having an empty string for PackageLoginUsername and PackageLoginPassword replacements.